### PR TITLE
fix: resolve Vercel Firebase and ESLint build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@types/firebase": "^2.4.32",
     "autoprefixer": "^10.4.21",
     "bcrypt": "^6.0.0",
+    "eslint": "^9",
+    "eslint-config-next": "15.5.3",
     "firebase": "^12.3.0",
     "next": "15.5.3",
     "next-auth": "^4.24.11",
@@ -38,8 +40,6 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.5.3",
     "typescript": "^5"
   }
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -13,6 +13,10 @@ export default function LoginForm() {
   const handleGoogleLogin = async () => {
     setError(null);
     try {
+      if (!FbAuth) {
+        throw new Error("Firebase Auth is not initialized");
+      }
+
       const provider = new GoogleAuthProvider();
       const result = await signInWithPopup(FbAuth, provider);
 

--- a/src/lib/auth/AuthContext.tsx
+++ b/src/lib/auth/AuthContext.tsx
@@ -32,6 +32,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!FbAuth) {
+      setLoading(false);
+      return;
+    }
+
     const unsubscribe = onAuthStateChanged(
       FbAuth,
       (firebaseUser: User | null) => {
@@ -54,7 +59,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const signOut = async () => {
     try {
-      await FbAuth.signOut();
+      if (FbAuth) {
+        await FbAuth.signOut();
+      }
     } catch (error) {
       console.error("Sign out error:", error);
     }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,19 +1,29 @@
 // src/lib/firebase.ts
-import { initializeApp, getApps } from "firebase/app";
-import { getAuth } from "firebase/auth";
+import { initializeApp, getApps, FirebaseApp } from "firebase/app";
+import { getAuth, Auth } from "firebase/auth";
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
 
-// ← ここで一度ログ出しすると確認できる
-console.log("FIREBASE CONFIG:", firebaseConfig);
+// クライアントサイドでのみFirebaseを初期化
+if (typeof window !== "undefined") {
+  const firebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  };
 
-const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  // 環境変数が設定されているか確認
+  if (!firebaseConfig.apiKey) {
+    console.warn("Firebase environment variables are not set properly");
+  } else {
+    console.log("FIREBASE CONFIG:", firebaseConfig);
+    app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+    auth = getAuth(app);
+  }
+}
 
-export const FbAuth = getAuth(app);
+export const FbAuth = auth;


### PR DESCRIPTION
- Move ESLint packages to dependencies for production builds
- Add type-safe Firebase initialization with server-side checks
- Prevent Firebase initialization on server-side rendering
- Add proper error handling for undefined FbAuth instances

Fixes: ESLint missing and Firebase invalid-api-key errors